### PR TITLE
Using css files instead of less

### DIFF
--- a/less/gn_admin_dutch.less
+++ b/less/gn_admin_dutch.less
@@ -1,5 +1,5 @@
-@import "gn_search_dutch.less";
-@import "../../../style/gn_admin";
+@import "gn_search_dutch.css";
+@import "gn_admin.css";
 
 body {
   background-image: none;
@@ -70,5 +70,5 @@ body {
   }
 }
 
-@import "gn_view_dutch.less";
+@import "gn_view_dutch.css";
 

--- a/less/gn_editor_dutch.less
+++ b/less/gn_editor_dutch.less
@@ -1,18 +1,18 @@
-@import "../../../style/gn_search.less";
-@import "../../../style/gn_editor";
-@import "gn_facets_dutch.less";
-@import "gn_pagination_dutch.less";
-@import "gn_onlinesrc_popup_dutch.less";
+@import "gn_search.css";
+@import "gn_editor.css";
+@import "gn_facets_dutch.css";
+@import "gn_pagination_dutch.css";
+@import "gn_onlinesrc_popup_dutch.css";
 // header
-@import "gn_header_dutch.less";
+@import "gn_header_dutch.css";
 // navigation
-@import "gn_navbar_dutch.less";
+@import "gn_navbar_dutch.css";
 // footer and bottombar
-@import "gn_footer_dutch.less";
+@import "gn_footer_dutch.css";
 // dutch style overrides
-@import "gn_view_dutch.less";
+@import "gn_view_dutch.css";
 // variables for manipulating the theme
-@import "gn_variables_dutch.less"; // must be last
+@import "gn_variables_dutch.css"; // must be last
 
 .page {
   padding-bottom: 60px;

--- a/less/gn_footer_dutch.less
+++ b/less/gn_footer_dutch.less
@@ -1,5 +1,5 @@
 // variables for manipulating the theme
-@import "gn_variables_dutch.less"; // must be last
+@import "gn_variables_dutch.css"; // must be last
 
 // ----- footer
 .footer {

--- a/less/gn_header_dutch.less
+++ b/less/gn_header_dutch.less
@@ -1,6 +1,6 @@
 @import "../../../style/gn_bootstrap.less"; // must be first
 // variables for manipulating the theme
-@import "gn_variables_dutch.less"; // must be last
+@import "gn_variables_dutch.css"; // must be last
 
 header {
   height: 80px;

--- a/less/gn_layout_dutch.less
+++ b/less/gn_layout_dutch.less
@@ -1,6 +1,6 @@
 @import "../../../style/gn_bootstrap.less"; // must be first
 // variables for manipulating the theme
-@import "gn_variables_dutch.less"; // must be last
+@import "gn_variables_dutch.css"; // must be last
 
 .gn-full {
   min-height: 100%;

--- a/less/gn_login_dutch.less
+++ b/less/gn_login_dutch.less
@@ -1,5 +1,5 @@
-@import "../../../style/gn_login";
-@import "gn_view_dutch.less";
+@import "gn_login.css";
+@import "gn_view_dutch.css";
 
 .page {
 	padding-top: 0;

--- a/less/gn_navbar_dutch.less
+++ b/less/gn_navbar_dutch.less
@@ -1,6 +1,6 @@
 @import "../../../style/gn_bootstrap.less"; // must be first
 // variables for manipulating the theme
-@import "gn_variables_dutch.less"; // must be last
+@import "gn_variables_dutch.css"; // must be last
 
 // breadcrumbs (in second toolbar/navbar)
 .crumb {

--- a/less/gn_result_dutch.less
+++ b/less/gn_result_dutch.less
@@ -1,5 +1,5 @@
-@import "../../../style/gn_search.less";
-// variables for manipulating the theme
+
+@import "gn_search.css";// variables for manipulating the theme
 @import "gn_variables_dutch.less"; // must be last
 
 // styling for a single result: metadata view

--- a/less/gn_results_dutch.less
+++ b/less/gn_results_dutch.less
@@ -1,6 +1,6 @@
 @import "../../../style/gn_bootstrap.less"; // must be first
 // variables for manipulating the theme
-@import "gn_variables_dutch.less"; // must be last
+@import "gn_variables_dutch.css"; // must be last
 
 .gn-row-results {
   padding-top: 15px;

--- a/less/gn_search_dutch.less
+++ b/less/gn_search_dutch.less
@@ -1,24 +1,24 @@
-@import "../../../style/gn_search.less";
-@import "../../../style/gn_metadata.less";
-@import "gn_facets_dutch.less";
-@import "gn_pagination_dutch.less";
-@import "gn_feedback_dutch.less";
+@import "gn_search.css";
+@import "gn_metadata.css";
+@import "gn_facets_dutch.css";
+@import "gn_pagination_dutch.css";
+@import "gn_feedback_dutch.css";
 // page layout
-@import "gn_layout_dutch.less";
+@import "gn_layout_dutch.css";
 // header
-@import "gn_header_dutch.less";
+@import "gn_header_dutch.css";
 // navigation
-@import "gn_navbar_dutch.less";
+@import "gn_navbar_dutch.css";
 // styling for a single result: metadata view
-@import "gn_result_dutch.less";
+@import "gn_result_dutch.css";
 // styling for all search results
-@import "gn_results_dutch.less";
+@import "gn_results_dutch.css";
 // main map and minimap
-@import "gn_map_dutch.less";
+@import "gn_map_dutch.css";
 // footer and bottombar
-@import "gn_footer_dutch.less";
+@import "gn_footer_dutch.css";
 // variables for manipulating the theme
-@import "gn_variables_dutch.less"; // must be last
+@import "gn_variables_dutch.css"; // must be last
 
 /* Hide the tabset selector because tab
    switch is available in the top tool bar */
@@ -513,6 +513,6 @@
   width: calc(~"100% + 50px");
 }
 
-@import "gn_view_dutch.less";
+@import "gn_view_dutch.css";
 
 

--- a/less/gn_view_dutch.less
+++ b/less/gn_view_dutch.less
@@ -4,7 +4,7 @@
    which has to be applied for all apps
    (ie. admin, search, login, editor). */
 
-@import "gn_variables_dutch.less"; // must be first
+@import "gn_variables_dutch.css"; // must be first
 
 @gnSpacing: 10px;
 @border-radius-large: 3px;


### PR DESCRIPTION
This is a workaround tested on IE9, IE10, IE11, Firefox and Chrome.

But still, this is a workaround, not sure if we should go like this or fix the problem in GeoNetwork instead.