### PR TITLE
Make the number of suggestion for location directive configurable

### DIFF
--- a/directives/multiLocationDirective.js
+++ b/directives/multiLocationDirective.js
@@ -13,7 +13,8 @@
             return {
                 restrict: 'A',
                 scope: {
-                    uriString: "="
+                    uriString: "=",
+                    limit: '@'
                 },
                 link: function (scope, element, attrs) {
 
@@ -71,6 +72,7 @@
                     }, {
                         name: 'keyword',
                         displayKey: 'label',
+                        limit: scope.limit || 5,
                         source: source
                     }).bind('typeahead:selected typeahead:autocompleted', $.proxy(function(obj, datum) {
                         this.tagsinput('add', datum);

--- a/templates/home.html
+++ b/templates/home.html
@@ -29,6 +29,7 @@
                 id="loc"
                 data-dutch-multi-location
                 data-thesaurus-key="external.place.regions"
+                data-limit="10"
                 data-uri-string="searchHomeParams.geometry"></select>
         <span class="form-control-feedback">
           <i class="fa fa-map-marker fa-2x"></i>

--- a/templates/searchForm.html
+++ b/templates/searchForm.html
@@ -26,6 +26,7 @@
                 id="sel-location"
                 data-dutch-multi-location
                 data-thesaurus-key="external.place.regions"
+                data-limit="10"
                 data-uri-string="searchObj.params.geometry"></select>
         <span class="form-control-feedback">
           <i class="fa fa-map-marker fa-2x"></i>

--- a/templates/searchFormIntra.html
+++ b/templates/searchFormIntra.html
@@ -26,6 +26,7 @@
                 id="sel-location"
                 data-dutch-multi-location
                 data-thesaurus-key="external.place.regions"
+                data-limit="10"
                 data-uri-string="searchObj.params.geometry"></select>
         <span class="form-control-feedback">
           <i class="fa fa-map-marker fa-2x"></i>


### PR DESCRIPTION
Adds the attribute limit to `dutchMultilocation` directive to configure the maximum number
of suggestions to show by the autocompleter.