### PR TITLE
Fix for the date field that is too wide

### DIFF
--- a/less/gn_editor_dutch.less
+++ b/less/gn_editor_dutch.less
@@ -479,12 +479,6 @@ form.gn-editor label.gn-mandatory:after, form.gn-editor .gn-mandatory > label:af
   }
 }
 
-// date fields (no time picker)
-[ng-app="gn_editor"] form.gn-editor .gn-date-picker > input[type=date], 
-[ng-app="gn_editor"] form.gn-editor .gn-date-picker > input[type=time] {
-  width: 100%;
-}
-
 // online resource panel
 .gn-onlinesrc-panel {
   .list-group {


### PR DESCRIPTION
Fix for the date field that is too wide in a non-Dutch schema (because there is also a time field in non-Dutch schemas)