### PR TITLE
Improve position for the typeahead for the drawmap panel in the editor

### DIFF
--- a/less/gn_editor_dutch.less
+++ b/less/gn_editor_dutch.less
@@ -183,6 +183,14 @@
     }
   }
 
+  // Draw map panel
+  .gn-drawmap-panel {
+    .tt-menu {
+      margin-top: 2px;
+      margin-left: -8px;
+    }
+  }
+
   // No indent
   form.gn-editor.gn-indent-none {
     .panel-default {


### PR DESCRIPTION
Improve position for the typeahead for the drawmap panel in the editor