### PR TITLE
Small fixes in the styling of the Editor and Map

### DIFF
--- a/less/gn_editor_dutch.less
+++ b/less/gn_editor_dutch.less
@@ -918,6 +918,7 @@ form.gn-editor .gn-field .col-sm-12 {
 
 // online resource panel
 .gn-onlinesrc-panel {
+  padding-top: 10px;
   .list-group {
     margin-bottom: 10px;
   }
@@ -938,9 +939,13 @@ form.gn-editor .gn-field .col-sm-12 {
       margin-left: -3px;
     }
   }
+  .list-inline {
+    .clearfix();
+  }
   .gn-list-thumb {
     margin: 0 0 4px 4px;
     border-radius: 0;
+    float: left;
     .btn-group {
       position: absolute;
       top: -1px;
@@ -1109,6 +1114,9 @@ form.gn-editor .gn-field .col-sm-12 {
   max-height: 350px;
   overflow: auto;
 }
+.tt-dropdown-menu {
+  margin-left: 0;
+}
 .tt-dropdown-menu *, .tt-menu * {
   font-size: 14px;
 }
@@ -1122,8 +1130,8 @@ form.gn-editor .gn-field .col-sm-12 {
     z-index: 120;
   }
   .tt-menu {
-    margin-top: 36px;
-    margin-left: 0;
+    margin-top: 2px;
+    margin-left: -8px;
     width: 100%;
     z-index: 120;
   }

--- a/less/gn_map_dutch.less
+++ b/less/gn_map_dutch.less
@@ -136,7 +136,7 @@
       margin-top: 0;
       border-radius: 0;
     }
-    @media (max-width: 750px) {
+    @media (max-width: @screen-sm-min) {
       [role=tooltip] {
         display: none;
       }


### PR DESCRIPTION
Small fixes in the styling of the Editor and Map

Changes:
- better breakpoint for hiding button labels in the map
- improved position of typeahead dropdown
- align thumbnails in `Downloads, views en links` panel

Contains fix for https://github.com/osgeonl/geonetwork-dutch-skin/issues/44