### PR TITLE
Show loading spinner centered in the results list, with a bigger size

### DIFF
--- a/less/gn_view_dutch.less
+++ b/less/gn_view_dutch.less
@@ -1042,6 +1042,7 @@ a:not(.btn) {
         color: @gn-menubar-color-active;
       }
     }
+
     .gn-search-filter {
       z-index: 100;
       padding: @gn-spacing-lg;
@@ -1136,6 +1137,17 @@ a:not(.btn) {
     .container-fluid {
       margin-left: -@gn-spacing;
       margin-right: -@gn-spacing;
+    }
+    .loading {
+      position: absolute;
+      top: 1.8em;
+      font-size: 40px;
+      left: 46%;
+      text-shadow: 0 0 1px white;
+      z-index: 200;
+      background: rgba(255,255,255,.7);
+      border-radius: 1em;
+      padding: .2em;
     }
     .gn-record-selected {
       background: none;


### PR DESCRIPTION
Fix the loading spinner display.

Without the fix:

![spinner-1](https://user-images.githubusercontent.com/1695003/205166994-60ce0327-4397-4a86-8f98-01ffcadbd068.png)

With the fix:

![spinner-2](https://user-images.githubusercontent.com/1695003/205167035-d2ba1688-8aa8-410c-858c-273c3f451642.png)


