### PR TITLE
Use facets directive to display the home page facets, instead of using custom code

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -140,42 +140,14 @@
   <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
     <div class="col-md-12" data-ng-show="homeFacet.list.length > 0">
       <h1 class="text-center">{{'byCategory'|translate}}</h1>
-      <div class="row">
-        <div
-          data-ng-show="homeFacet.key !== 'inspireThemeUri'"
-          data-ng-init="aggResponse = searchInfo.aggregations[homeFacet.key]"
-          data-ng-repeat="facet in searchInfo.aggregations[homeFacet.key].buckets"
-          class="col-xs-12 col-sm-6 col-md-6 col-lg-4 gn-topic"
-        >
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <a
-                class="pull-left clearfix"
-                title="{{facet.key}}"
-                role="link"
-                data-ng-init="field = (aggResponse.meta && aggResponse.meta.field) || homeFacet.key"
-                data-ng-href='#/search?query_string={"{{field}}": {"{{facet.key}}": true} }'
-              >
-                <span>
-                  <i
-                    class="fa fa-2x pull-left gn-icon-{{facet.key.toLowerCase().replace('/', '').replace(' ', '')}}"
-                  >
-                  </i>
-                </span>
-                <h2>
-                  <span class="clamp-2"
-                    >{{facet.key | facetTranslator: homeFacet.key |
-                    capitalize}}</span
-                  >
-                </h2>
-              </a>
-            </div>
-            <div class="panel-footer">
-              <span class="gn-icon-count">{{facet.doc_count}}</span>
-            </div>
-          </div>
-        </div>
-      </div>
+
+      <div
+        data-ng-if="homeFacet"
+        es-facet-cards="homeFacet.key"
+        data-home-facet="homeFacet"
+        data-search-info="searchInfo"
+        data-agg-config="aggConfig"
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
This allows to benefit from https://github.com/geonetwork/core-geonetwork/pull/7569, to allow sorting the topic categories alphabetically.