### PR TITLE
Metadata editor / Unify size of control-label style with label elements

### DIFF
--- a/less/gn_editor_dutch.less
+++ b/less/gn_editor_dutch.less
@@ -149,7 +149,7 @@
     }
     .control-label {
       color: #333333;
-      font-size: 12px;
+      font-size: 14px !important;
       font-weight: bold;
     }
     input[type="text"],


### PR DESCRIPTION
Before:

<img width="1003" height="185" alt="image" src="https://github.com/user-attachments/assets/c06921cb-5b87-4a8c-94ac-6e8aac097c71" />

After:

<img width="994" height="178" alt="image" src="https://github.com/user-attachments/assets/9f8a8f9b-b7ab-4b30-b004-c26bd9fd8922" />

