### PR TITLE
Record view / Hide empty keyword sections

### DIFF
--- a/templates/recordView4.html
+++ b/templates/recordView4.html
@@ -220,7 +220,7 @@
                     <!-- keywords -->
                     <tr
                       data-ng-repeat="(key, t) in mdView.current.record.allKeywords"
-                      ng-if="key.indexOf('th_httpinspireeceuropaeutheme') == -1"
+                      ng-if="key.indexOf('th_httpinspireeceuropaeutheme') == -1 && t.keywords.length > 0"
                     >
                       <th>
                         {{ (t.multilingualTitle.default || t.title || key) | translate }}

--- a/templates/recordView4.html
+++ b/templates/recordView4.html
@@ -220,7 +220,7 @@
                     <!-- keywords -->
                     <tr
                       data-ng-repeat="(key, t) in mdView.current.record.allKeywords"
-                      ng-if="key.indexOf('th_httpinspireeceuropaeutheme') == -1 && t.keywords.length > 0"
+                      data-ng-if="key.indexOf('th_httpinspireeceuropaeutheme') == -1 && t.keywords.length > 0"
                     >
                       <th>
                         {{ (t.multilingualTitle.default || t.title || key) | translate }}


### PR DESCRIPTION
In the metadata page, keyword sections without keywords were displayed with the related thesaurus title and empty value.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/3a760fd3-f21b-474f-bfdf-ea0abd39761a" />

With the change keyword sections without keywords are not displayed.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/590b68f6-6fdc-4036-996c-d416618780dc" />
