### PR TITLE
[Backport 4.2.x] Record view / Hide empty keyword sections

### DIFF
--- a/templates/recordView4.html
+++ b/templates/recordView4.html
@@ -201,7 +201,7 @@
                     <!-- keywords -->
                     <tr
                       data-ng-repeat="(key, t) in mdView.current.record.allKeywords"
-                      ng-if="key.indexOf('th_httpinspireeceuropaeutheme') == -1"
+                      ng-if="key.indexOf('th_httpinspireeceuropaeutheme') == -1 && t.keywords.length > 0"
                     >
                       <th>{{ (t.multilingualTitle.default || t.title || key) | translate }}</th>
                       <td>


### PR DESCRIPTION
Backport of #83 to the 4.2.x branch.

Hides keyword section rows in the record view when the keyword group has no keywords, while keeping the existing INSPIRE theme exclusion.

The `allKeywords` index structure is identical in GN 4.2.x: each thesaurus entry always has a `keywords` array, and the indexer emits entries even when that array is empty, so the `t.keywords.length > 0` guard correctly suppresses the empty rows. The cherry-pick applied cleanly.